### PR TITLE
Dataset and misc tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,4 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-*_logs/
-*_checkpoints/
+results/*

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ conda install -c dglteam dgl=0.6.1=py39_0
 
 The classification model can be trained using:
 ```
-python classification.py train --dataset solidletters --dataset_path /path/to/solidletters --epochs 100 --batch_size 64
+python classification.py train --dataset solidletters --dataset_path /path/to/solidletters --max_epochs 100 --batch_size 64
 ```
 
 Only the SolidLetters dataset is currently supported for classification.
 
 The segmentation model can be trained similarly:
 ```
-python segmentation.py train --dataset mfcad --dataset_path /path/to/mfcad --epochs 100 --batch_size 64
+python segmentation.py train --dataset mfcad --dataset_path /path/to/mfcad --max_epochs 100 --batch_size 64
 ```
 
 The MFCAD and Fusion 360 Gallery segmentation datasets are supported for segmentation.

--- a/README.md
+++ b/README.md
@@ -32,29 +32,29 @@ conda install -c dglteam dgl=0.6.1=py39_0
 
 The classification model can be trained using:
 ```
-python classification.py train --dataset solidletters --dataset_path /path/to/solidletters --max_epochs 100 --batch_size 64
+python classification.py train --dataset solidletters --dataset_path /path/to/solidletters --max_epochs 100 --batch_size 64 --experiment_name classification
 ```
 
 Only the SolidLetters dataset is currently supported for classification.
 
 The segmentation model can be trained similarly:
 ```
-python segmentation.py train --dataset mfcad --dataset_path /path/to/mfcad --max_epochs 100 --batch_size 64
+python segmentation.py train --dataset mfcad --dataset_path /path/to/mfcad --max_epochs 100 --batch_size 64 --experiment_name segmentation
 ```
 
 The MFCAD and Fusion 360 Gallery segmentation datasets are supported for segmentation.
 
-The logs will be stored in a folder called `classification_logs` or `segmentation_logs` based on the experiment, and can be monitored with Tensorboard:
+The logs and checkpoints will be stored in a folder called `results/classification` or `results/segmentation` based on the experiment name, and can be monitored with Tensorboard:
 
 ```
-tensorboard --logdir *_logs
+tensorboard --logdir results/<experiment_name>
 ```
 
 ## Testing
-The best checkpoints based on the smallest validation loss are saved in the `classification_checkpoints` or `segmentation_checkpoints` folder. The checkpoints can be used to test the model as follows:
+The best checkpoints based on the smallest validation loss are saved in the results folder. The checkpoints can be used to test the model as follows:
 
 ```
-python segmentation.py test --dataset mfcad --dataset_path /path/to/mfcad/ --checkpoint ./segmentation_checkpoints/best-epoch=XX-val_loss=X.XX.ckpt
+python segmentation.py test --dataset mfcad --dataset_path /path/to/mfcad/ --checkpoint ./results/segmentation/best.ckpt
 ```
 
 ## Data

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python segmentation.py train --dataset mfcad --dataset_path /path/to/mfcad --max
 
 The MFCAD and Fusion 360 Gallery segmentation datasets are supported for segmentation.
 
-The logs and checkpoints will be stored in a folder called `results/classification` or `results/segmentation` based on the experiment name, and can be monitored with Tensorboard:
+The logs and checkpoints will be stored in a folder called `results/classification` or `results/segmentation` based on the experiment name and timestamp, and can be monitored with Tensorboard:
 
 ```
 tensorboard --logdir results/<experiment_name>

--- a/classification.py
+++ b/classification.py
@@ -1,6 +1,6 @@
 import argparse
+import pathlib
 
-import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
@@ -14,30 +14,43 @@ parser.add_argument(
 )
 parser.add_argument("--dataset", choices=("solidletters",), help="Dataset to train on")
 parser.add_argument("--dataset_path", type=str, help="Path to dataset")
-parser.add_argument("--epochs", type=int, default=100, help="Number of epochs to train")
 parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
-parser.add_argument("--cpu", action="store_true", help="Use the CPU for training/testing")
+parser.add_argument(
+    "--num_workers",
+    type=int,
+    default=0,
+    help="Number of workers for the dataloader. NOTE: set this to 0 on Windows, any other value leads to poor performance",
+)
 parser.add_argument(
     "--checkpoint",
     type=str,
     default=None,
     help="Checkpoint file to load weights from for testing",
 )
+parser.add_argument(
+    "--experiment_name",
+    type=str,
+    default="segmentation",
+    help="Experiment name (used to create folder inside ./results/ to save logs and checkpoints)",
+)
 
 parser = Trainer.add_argparse_args(parser)
 args = parser.parse_args()
 
+results_path = (
+    pathlib.Path(__file__).parent.joinpath("results").joinpath(args.experiment_name)
+)
+if not results_path.exists():
+    results_path.mkdir(parents=True, exist_ok=True)
+
 checkpoint_callback = ModelCheckpoint(
-    monitor="val_loss",
-    dirpath="classification_checkpoints",
-    filename="best-{epoch}-{val_loss:.2f}",
-    save_last=True,
+    monitor="val_loss", dirpath=str(results_path), filename="best", save_last=True,
 )
 
 trainer = Trainer.from_argparse_args(
     args,
     callbacks=[checkpoint_callback],
-    logger=TensorBoardLogger("classification_logs"),
+    logger=TensorBoardLogger(results_path.joinpath(args.experiment_name)),
 )
 
 if args.dataset == "solidletters":
@@ -51,13 +64,19 @@ if args.traintest == "train":
     model = Classification(num_classes=Dataset.num_classes())
     train_data = Dataset(root_dir=args.dataset_path, split="train")
     val_data = Dataset(root_dir=args.dataset_path, split="val")
-    train_loader = train_data.get_dataloader(batch_size=args.batch_size, shuffle=True)
-    val_loader = val_data.get_dataloader(batch_size=args.batch_size, shuffle=False)
+    train_loader = train_data.get_dataloader(
+        batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers
+    )
+    val_loader = val_data.get_dataloader(
+        batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers
+    )
     trainer.fit(model, train_loader, val_loader)
 else:
     # Test
     test_data = Dataset(root_dir=args.dataset_path, split="test")
-    test_loader = test_data.get_dataloader(batch_size=args.batch_size, shuffle=False)
+    test_loader = test_data.get_dataloader(
+        batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers
+    )
     model = Classification.load_from_checkpoint(args.checkpoint)
     results = trainer.test(model=model, test_dataloaders=[test_loader], verbose=False)
     print(

--- a/classification.py
+++ b/classification.py
@@ -24,6 +24,7 @@ parser.add_argument(
     help="Checkpoint file to load weights from for testing",
 )
 
+parser = Trainer.add_argparse_args(parser)
 args = parser.parse_args()
 
 checkpoint_callback = ModelCheckpoint(
@@ -33,12 +34,9 @@ checkpoint_callback = ModelCheckpoint(
     save_last=True,
 )
 
-use_cpu = args.cpu or (not torch.cuda.is_available())
-trainer = Trainer(
-    gpus=None if use_cpu else 1,
+trainer = Trainer.from_argparse_args(
+    args,
     callbacks=[checkpoint_callback],
-    check_val_every_n_epoch=1,
-    max_epochs=args.epochs,
     logger=TensorBoardLogger("classification_logs"),
 )
 

--- a/classification.py
+++ b/classification.py
@@ -30,7 +30,7 @@ parser.add_argument(
 parser.add_argument(
     "--experiment_name",
     type=str,
-    default="segmentation",
+    default="classification",
     help="Experiment name (used to create folder inside ./results/ to save logs and checkpoints)",
 )
 
@@ -73,6 +73,7 @@ if args.traintest == "train":
     trainer.fit(model, train_loader, val_loader)
 else:
     # Test
+    assert args.checkpoint is not None, "Expected the --checkpoint argument to be provided"
     test_data = Dataset(root_dir=args.dataset_path, split="test")
     test_loader = test_data.get_dataloader(
         batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers

--- a/classification.py
+++ b/classification.py
@@ -1,5 +1,6 @@
 import argparse
 import pathlib
+import time
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
@@ -43,14 +44,23 @@ results_path = (
 if not results_path.exists():
     results_path.mkdir(parents=True, exist_ok=True)
 
+# Define a path to save the results based date and time. E.g.
+# results/args.experiment_name/0430/123103
+month_day = time.strftime("%m%d")
+hour_min_second = time.strftime("%H%M%S")
 checkpoint_callback = ModelCheckpoint(
-    monitor="val_loss", dirpath=str(results_path), filename="best", save_last=True,
+    monitor="val_loss",
+    dirpath=str(results_path.joinpath(month_day, hour_min_second)),
+    filename="best",
+    save_last=True,
 )
 
 trainer = Trainer.from_argparse_args(
     args,
     callbacks=[checkpoint_callback],
-    logger=TensorBoardLogger(results_path.joinpath(args.experiment_name)),
+    logger=TensorBoardLogger(
+        str(results_path), name=month_day, version=hour_min_second,
+    ),
 )
 
 if args.dataset == "solidletters":
@@ -58,9 +68,23 @@ if args.dataset == "solidletters":
 else:
     raise ValueError("Unsupported dataset")
 
-
 if args.traintest == "train":
     # Train/val
+    print(
+        f"""
+-----------------------------------------------------------------------------------
+UV-Net Classification
+-----------------------------------------------------------------------------------
+Logs written to results/{args.experiment_name}/{month_day}/{hour_min_second}
+
+To monitor the logs, run:
+tensorboard --logdir results/{args.experiment_name}/{month_day}/{hour_min_second}
+
+The trained model with the best validation loss will be written to:
+results/{args.experiment_name}/{month_day}/{hour_min_second}/best.ckpt
+-----------------------------------------------------------------------------------
+    """
+    )
     model = Classification(num_classes=Dataset.num_classes())
     train_data = Dataset(root_dir=args.dataset_path, split="train")
     val_data = Dataset(root_dir=args.dataset_path, split="val")
@@ -73,7 +97,9 @@ if args.traintest == "train":
     trainer.fit(model, train_loader, val_loader)
 else:
     # Test
-    assert args.checkpoint is not None, "Expected the --checkpoint argument to be provided"
+    assert (
+        args.checkpoint is not None
+    ), "Expected the --checkpoint argument to be provided"
     test_data = Dataset(root_dir=args.dataset_path, split="test")
     test_loader = test_data.get_dataloader(
         batch_size=args.batch_size, shuffle=False, num_workers=args.num_workers

--- a/datasets/base.py
+++ b/datasets/base.py
@@ -35,8 +35,8 @@ class BaseDataset(Dataset):
             self.graphs[i].ndata["x"], center, scale = util.center_and_scale_uvgrid(
                 self.graphs[i].ndata["x"], return_center_scale=True
             )
-            self.graphs[i].edata["x"] -= center
-            self.graphs[i].edata["x"] *= scale
+            self.graphs[i].edata["x"][..., :3] -= center
+            self.graphs[i].edata["x"][..., :3] *= scale
 
     def __len__(self):
         return len(self.graphs)

--- a/datasets/base.py
+++ b/datasets/base.py
@@ -19,6 +19,8 @@ class BaseDataset(Dataset):
             if not fn.exists():
                 continue
             graph = self.load_one_graph(fn)
+            if graph is None:
+                continue
             self.graphs.append(graph)
             self.files.append(fn)
         if center_and_scale:

--- a/datasets/base.py
+++ b/datasets/base.py
@@ -1,0 +1,60 @@
+from torch.utils.data import Dataset, DataLoader
+import dgl
+from dgl.data.utils import load_graphs
+from datasets import util
+from tqdm import tqdm
+from abc import abstractmethod
+
+
+class BaseDataset(Dataset):
+    @staticmethod
+    @abstractmethod
+    def num_classes():
+        pass
+
+    def load_graphs(self, file_paths, center_and_scale=True):
+        self.files = []
+        self.graphs = []
+        for fn in tqdm(file_paths):
+            if not fn.exists():
+                continue
+            graph = self.load_one_graph(fn)
+            self.graphs.append(graph)
+            self.files.append(fn)
+        if center_and_scale:
+            self.center_and_scale()
+    
+    def load_one_graph(self, file_path):
+        graph = load_graphs(str(file_path))[0][0]
+        return graph
+
+    def center_and_scale(self):
+        for i in range(len(self.graphs)):
+            self.graphs[i].ndata["x"] = util.center_and_scale_uvgrid(
+                self.graphs[i].ndata["x"]
+            )
+
+    def __len__(self):
+        return len(self.graphs)
+
+    def __getitem__(self, idx):
+        graph = self.graphs[idx]
+        if self.random_rotate:
+            rotation = util.get_random_rotation()
+            graph.ndata["x"] = util.rotate_uvgrid(graph.ndata["x"], rotation)
+            graph.edata["x"] = util.rotate_uvgrid(graph.edata["x"], rotation)
+        return graph
+
+    def _collate(self, batch):
+        bg = dgl.batch(batch)
+        return bg
+
+    def get_dataloader(self, batch_size=128, shuffle=True, num_workers=0):
+        return DataLoader(
+            self,
+            batch_size=batch_size,
+            shuffle=shuffle,
+            collate_fn=self._collate,
+            num_workers=num_workers,  # Can be set to non-zero on Linux
+            drop_last=True,
+        )

--- a/datasets/base.py
+++ b/datasets/base.py
@@ -32,9 +32,11 @@ class BaseDataset(Dataset):
 
     def center_and_scale(self):
         for i in range(len(self.graphs)):
-            self.graphs[i].ndata["x"] = util.center_and_scale_uvgrid(
-                self.graphs[i].ndata["x"]
+            self.graphs[i].ndata["x"], center, scale = util.center_and_scale_uvgrid(
+                self.graphs[i].ndata["x"], return_center_scale=True
             )
+            self.graphs[i].edata["x"] -= center
+            self.graphs[i].edata["x"] *= scale
 
     def __len__(self):
         return len(self.graphs)

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -1,24 +1,20 @@
 import numpy as np
+from datasets.base import BaseDataset
 import pathlib
 from torch.utils.data import Dataset, DataLoader
-import dgl
 import torch
-from dgl.data.utils import load_graphs
 import json
 from datasets import util
 from tqdm import tqdm
 
 
-class FusionGalleryDataset(Dataset):
+class FusionGalleryDataset(BaseDataset):
     @staticmethod
     def num_classes():
         return 8
 
     def __init__(
-        self,
-        root_dir,
-        split="train",
-        center_and_scale=True,
+        self, root_dir, split="train", center_and_scale=True, random_rotate=False,
     ):
         """
         Load the Fusion Gallery dataset from:
@@ -26,16 +22,20 @@ class FusionGalleryDataset(Dataset):
         Peter Meltzer, Hooman Shayani. "BRepNet: A topological message passing system
         for solid models," CVPR 2021.
 
-        :param root_dir: Root path to the dataset
-        :param split: string Whether train, val or test set
+        Args:
+            root_dir (str): Root path of dataset
+            split (str, optional): Data split to load. Defaults to "train".
+            center_and_scale (bool, optional): Whether to center and scale the solid. Defaults to True.
+            random_rotate (bool, optional): Whether to apply random rotations to the solid in 90 degree increments. Defaults to False.
         """
         path = pathlib.Path(root_dir)
+        self.path = path
         assert split in ("train", "val", "test")
 
         with open(str(path.joinpath("train_test.json")), "r") as read_file:
             filelist = json.load(read_file)
 
-        # NOTE: Using a held out out validation set may be better.
+        # NOTE: Using a held out validation set may be better.
         # But it's not easy to perform stratified sampling on some rare classes
         # which only show up on a few solids.
         if split in ("train", "val"):
@@ -43,57 +43,20 @@ class FusionGalleryDataset(Dataset):
         else:
             split_filelist = filelist["test"]
 
-        self.center_and_scale = center_and_scale
+        self.random_rotate = random_rotate
 
-        all_files = []
-        # Load graphs and store their filenames for loading labels next
-        for fn in split_filelist:
-            all_files.append(path.joinpath("graph").joinpath(fn + ".bin"))
+        # Call base class method to load all graphs
+        print(f"Loading {split} graphs...")
+        all_files = [path.joinpath("graph").joinpath(fn + ".bin") for fn in split_filelist]
+        self.load_graphs(all_files, center_and_scale)
+        print("Done loading {} files".format(len(self.files)))
 
-        # Load labels from the json files in the subfolder
-        self.files = []
-        self.graphs = []
-        print(f"Loading {split} data...")
-        for fn in tqdm(all_files):
-            if not fn.exists():
-                continue
-            graph = load_graphs(str(fn))[0][0]
-            label = np.loadtxt(
-                path.joinpath("breps").joinpath(fn.stem + ".seg"), dtype=np.int, ndmin=1
-            )
-            if label.size != graph.number_of_nodes():
-                # Skip files where the number of faces and labels don't match
-                # print(
-                #     f"WARN: number of faces  and labels do not match in {fn.stem}: {label.size} vs. {graph.number_of_nodes()}"
-                # )
-                continue
-            self.files.append(fn)
-            graph.ndata["y"] = torch.tensor(label).long()
-            self.graphs.append(graph)
-
-        if self.center_and_scale:
-            for i in range(len(self.graphs)):
-                self.graphs[i].ndata["x"] = util.center_and_scale_uvsolid(
-                    self.graphs[i].ndata["x"]
-                )
-
-    def __len__(self):
-        return len(self.graphs)
-
-    def __getitem__(self, idx):
-        graph = self.graphs[idx]
-        return graph
-
-    def _collate(self, batch):
-        bg = dgl.batch(batch)
-        return bg
-
-    def get_dataloader(self, batch_size=128, shuffle=True):
-        return DataLoader(
-            self,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            collate_fn=self._collate,
-            num_workers=0,  # Can be set to non-zero on Linux
-            drop_last=True,
+    def load_one_graph(self, file_path):
+        # Load the graph use base class method
+        graph = super().load_one_graph(file_path)
+        # Additionally load the label and store it as node data
+        label = np.loadtxt(
+            self.path.joinpath("breps").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
         )
+        graph.ndata["y"] = torch.tensor(label).long()
+        return graph

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -58,5 +58,7 @@ class FusionGalleryDataset(BaseDataset):
         label = np.loadtxt(
             self.path.joinpath("breps").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
         )
+        if graph.number_of_nodes() != label.shape[0]:
+            return None
         graph.ndata["y"] = torch.tensor(label).long()
         return graph

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -51,19 +51,19 @@ class FusionGalleryDataset(BaseDataset):
         self.random_rotate = random_rotate
 
         # Call base class method to load all graphs
-        print(f"Loading {split} graphs...")
+        print(f"Loading {split} data...")
         all_files = [path.joinpath("graph").joinpath(fn + ".bin") for fn in split_filelist]
         self.load_graphs(all_files, center_and_scale)
-        print("Done loading {} files".format(len(self.files)))
+        print("Done loading {} files".format(len(self.data)))
 
     def load_one_graph(self, file_path):
-        # Load the graph use base class method
-        graph = super().load_one_graph(file_path)
+        # Load the graph using base class method
+        sample = super().load_one_graph(file_path)
         # Additionally load the label and store it as node data
         label = np.loadtxt(
             self.path.joinpath("breps").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
         )
-        if graph.number_of_nodes() != label.shape[0]:
+        if sample["graph"].number_of_nodes() != label.shape[0]:
             return None
-        graph.ndata["y"] = torch.tensor(label).long()
-        return graph
+        sample["graph"].ndata["y"] = torch.tensor(label).long()
+        return sample

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -1,11 +1,9 @@
 import numpy as np
 from datasets.base import BaseDataset
 import pathlib
-from torch.utils.data import Dataset, DataLoader
 import torch
 import json
-from datasets import util
-from tqdm import tqdm
+from sklearn.model_selection import train_test_split
 
 
 class FusionGalleryDataset(BaseDataset):
@@ -39,7 +37,14 @@ class FusionGalleryDataset(BaseDataset):
         # But it's not easy to perform stratified sampling on some rare classes
         # which only show up on a few solids.
         if split in ("train", "val"):
-            split_filelist = filelist["train"]
+            full_train_filelist = filelist["train"]
+            train_filesplit, val_filesplit = train_test_split(
+                full_train_filelist, test_size=0.2, random_state=42
+            )
+            if split == "train":
+                split_filelist = train_filesplit
+            else:
+                split_filelist = val_filesplit
         else:
             split_filelist = filelist["test"]
 

--- a/datasets/mfcad.py
+++ b/datasets/mfcad.py
@@ -1,4 +1,4 @@
-import numpy as np
+from datasets.base import BaseDataset
 import pathlib
 from torch.utils.data import Dataset, DataLoader
 import dgl
@@ -9,16 +9,13 @@ from datasets import util
 from tqdm import tqdm
 
 
-class MFCADDataset(Dataset):
+class MFCADDataset(BaseDataset):
     @staticmethod
     def num_classes():
         return 16
 
     def __init__(
-        self,
-        root_dir,
-        split="train",
-        center_and_scale=True,
+        self, root_dir, split="train", center_and_scale=True, random_rotate=False,
     ):
         """
         Load the MFCAD dataset from:
@@ -30,10 +27,14 @@ class MFCADDataset(Dataset):
         and Information in Engineering Conference, IDETC-CIE.
         ASME, 2020.
 
-        :param root_dir: Root path to the dataset
-        :param split: string Whether train, val or test set
+        Args:
+            root_dir (str): Root path of dataset
+            split (str, optional): Data split to load. Defaults to "train".
+            center_and_scale (bool, optional): Whether to center and scale the solid. Defaults to True.
+            random_rotate (bool, optional): Whether to apply random rotations to the solid in 90 degree increments. Defaults to False.
         """
         path = pathlib.Path(root_dir)
+        self.path = path
         assert split in ("train", "val", "test")
 
         with open(str(str(path.joinpath("split.json"))), "r") as read_file:
@@ -46,17 +47,19 @@ class MFCADDataset(Dataset):
         else:
             split_filelist = filelist["test"]
 
-        self.center_and_scale = center_and_scale
+        self.random_rotate = random_rotate
 
-        self.files = []
+        all_files = []
         for fn in split_filelist:
-            self.files.append(path.joinpath("graph").joinpath(fn + ".bin"))
+            all_files.append(path.joinpath("graph").joinpath(fn + ".bin"))
+
+        # Load graphs
+        print(f"Loading {split} graphs...")
+        self.load_graphs(all_files, center_and_scale)
 
         # Load labels from the json files in the subfolder
-        print(f"Loading {split} data...")
-        self.graphs = []
-        for fn in tqdm(self.files):
-            graph = load_graphs(str(fn))[0][0]
+        print(f"Loading {split} labels...")
+        for i, fn in enumerate(tqdm(self.files)):
             label_file = path.joinpath("labels").joinpath(fn.stem + "_ids.json")
             with open(str(label_file), "r") as read_file:
                 labels_data = json.load(read_file)
@@ -64,37 +67,20 @@ class MFCADDataset(Dataset):
             for face in labels_data["body"]["faces"]:
                 index = face["segment"]["index"]
                 label.append(index)
-            graph.ndata["y"] = torch.tensor(label).long()
-            self.graphs.append(graph)
-
-        self.num_face_channels = self.graphs[0].ndata["x"].size(3)
-        self.num_edge_channels = self.graphs[0].edata["x"].size(2)
-
-        if self.center_and_scale:
-            for i in range(len(self.graphs)):
-                self.graphs[i].ndata["x"] = util.center_and_scale_uvsolid(
-                    self.graphs[i].ndata["x"]
-                )
+            self.graphs[i].ndata["y"] = torch.tensor(label).long()
 
         print("Done loading {} files".format(len(self.files)))
 
-    def __len__(self):
-        return len(self.files)
-
-    def __getitem__(self, idx):
-        graph = self.graphs[idx]
+    def load_one_graph(self, file_path):
+        # Load the graph use base class method
+        graph = super().load_one_graph(file_path)
+        # Additionally load the label and store it as node data
+        label_file = self.path.joinpath("labels").joinpath(file_path.stem + "_ids.json")
+        with open(str(label_file), "r") as read_file:
+            labels_data = json.load(read_file)
+        label = []
+        for face in labels_data["body"]["faces"]:
+            index = face["segment"]["index"]
+            label.append(index)
+        graph.ndata["y"] = torch.tensor(label).long()
         return graph
-
-    def _collate(self, batch):
-        bg = dgl.batch(batch)
-        return bg
-
-    def get_dataloader(self, batch_size=128, shuffle=True):
-        return DataLoader(
-            self,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            collate_fn=self._collate,
-            num_workers=0,  # Can be set to non-zero on Linux
-            drop_last=True,
-        )

--- a/datasets/mfcad.py
+++ b/datasets/mfcad.py
@@ -1,12 +1,7 @@
 from datasets.base import BaseDataset
 import pathlib
-from torch.utils.data import Dataset, DataLoader
-import dgl
 import torch
-from dgl.data.utils import load_graphs
 import json
-from datasets import util
-from tqdm import tqdm
 
 
 class MFCADDataset(BaseDataset):
@@ -54,26 +49,13 @@ class MFCADDataset(BaseDataset):
             all_files.append(path.joinpath("graph").joinpath(fn + ".bin"))
 
         # Load graphs
-        print(f"Loading {split} graphs...")
+        print(f"Loading {split} data...")
         self.load_graphs(all_files, center_and_scale)
-
-        # Load labels from the json files in the subfolder
-        print(f"Loading {split} labels...")
-        for i, fn in enumerate(tqdm(self.files)):
-            label_file = path.joinpath("labels").joinpath(fn.stem + "_ids.json")
-            with open(str(label_file), "r") as read_file:
-                labels_data = json.load(read_file)
-            label = []
-            for face in labels_data["body"]["faces"]:
-                index = face["segment"]["index"]
-                label.append(index)
-            self.graphs[i].ndata["y"] = torch.tensor(label).long()
-
-        print("Done loading {} files".format(len(self.files)))
+        print("Done loading {} files".format(len(self.data)))
 
     def load_one_graph(self, file_path):
-        # Load the graph use base class method
-        graph = super().load_one_graph(file_path)
+        # Load the graph using base class method
+        sample = super().load_one_graph(file_path)
         # Additionally load the label and store it as node data
         label_file = self.path.joinpath("labels").joinpath(file_path.stem + "_ids.json")
         with open(str(label_file), "r") as read_file:
@@ -82,5 +64,5 @@ class MFCADDataset(BaseDataset):
         for face in labels_data["body"]["faces"]:
             index = face["segment"]["index"]
             label.append(index)
-        graph.ndata["y"] = torch.tensor(label).long()
-        return graph
+        sample["graph"].ndata["y"] = torch.tensor(label).long()
+        return sample

--- a/datasets/solidletters.py
+++ b/datasets/solidletters.py
@@ -1,16 +1,10 @@
 import pathlib
-import random
 import string
 
-import dgl
-import numpy as np
 import torch
-from dgl.data.utils import load_graphs, save_graphs
 from sklearn.model_selection import train_test_split
-from torch.utils.data import DataLoader, Dataset
-from tqdm import tqdm
 
-from datasets import util
+from datasets.base import BaseDataset
 
 
 def _get_filenames(root_dir, filelist):
@@ -33,7 +27,7 @@ def _char_to_label(char):
     return CHAR2LABEL[char.lower()]
 
 
-class SolidLetters(Dataset):
+class SolidLetters(BaseDataset):
     @staticmethod
     def num_classes():
         return 26
@@ -81,7 +75,7 @@ class SolidLetters(Dataset):
         # Load the graph using base class method
         sample = super().load_one_graph(file_path)
         # Additionally get the label from the filename and store it in the sample dict
-        sample["label"] = _char_to_label(file_path.stem[0])
+        sample["label"] = torch.tensor([_char_to_label(file_path.stem[0])]).long()
         return sample
 
     def _collate(self, batch):

--- a/datasets/solidletters.py
+++ b/datasets/solidletters.py
@@ -34,8 +34,8 @@ def _char_to_label(char):
 
 
 class SolidLetters(Dataset):
-    @classmethod
-    def num_classes(cls):
+    @staticmethod
+    def num_classes():
         return 26
 
     def __init__(
@@ -43,64 +43,48 @@ class SolidLetters(Dataset):
         root_dir,
         split="train",
         center_and_scale=True,
+        random_rotate=False,
     ):
         """
-        Load and create the SolidMNIST dataset
-        :param root_dir: Root path to the dataset (UV bin files are expected to be in a 'bin' subfolder)
-        :param split: string Whether train, val or test set
-        :param center_and_scale: Center and scale the UV grids
+        Load the SolidLetters dataset
+
+        Args:
+            root_dir (str): Root path to the dataset
+            split (str, optional): Split (train, val, or test) to load. Defaults to "train".
+            center_and_scale (bool, optional): Whether to center and scale the solid. Defaults to True.
+            random_rotate (bool, optional): Whether to apply random rotations to the solid in 90 degree increments. Defaults to False.
         """
         assert split in ("train", "val", "test")
         path = pathlib.Path(root_dir)
 
-        self.center_and_scale = center_and_scale
+        self.random_rotate = random_rotate
 
         if split in ("train", "val"):
-            bin_files = _get_filenames(path, filelist="train.txt")
+            file_paths = _get_filenames(path, filelist="train.txt")
             # The first character of filename must be the alphabet
-            labels = [_char_to_label(fn.stem[0]) for fn in bin_files]
-            train_files, val_files, train_labels, val_labels = train_test_split(
-                bin_files, labels, test_size=0.2, random_state=42, stratify=labels,
+            labels = [_char_to_label(fn.stem[0]) for fn in file_paths]
+            train_files, val_files = train_test_split(
+                file_paths, test_size=0.2, random_state=42, stratify=labels,
             )
             if split == "train":
-                self.graph_files = train_files
-                self.labels = train_labels
+                file_paths = train_files
             elif split == "val":
-                self.graph_files = val_files
-                self.labels = val_labels
+                file_paths = val_files
         elif split == "test":
-            self.graph_files = _get_filenames(path, filelist="test.txt")
-            self.labels = [_char_to_label(fn.stem[0]) for fn in self.graph_files]
+            file_paths = _get_filenames(path, filelist="test.txt")
 
-        self.graphs = []
         print(f"Loading {split} data...")
-        for fn in tqdm(self.graph_files):
-            self.graphs.append(load_graphs(str(fn))[0][0])
-        if self.center_and_scale:
-            for i in range(len(self.graphs)):
-                self.graphs[i].ndata["x"] = util.center_and_scale_uvgrid(
-                    self.graphs[i].ndata["x"]
-                )
+        self.load_graphs(file_paths, center_and_scale)
+        print("Done loading {} files".format(len(self.data)))
 
-    def __len__(self):
-        return len(self.graph_files)
-
-    def __getitem__(self, idx):
-        graph = self.graphs[idx]
-        return graph, torch.tensor([self.labels[idx]]).long()
+    def load_one_graph(self, file_path):
+        # Load the graph using base class method
+        sample = super().load_one_graph(file_path)
+        # Additionally get the label from the filename and store it in the sample dict
+        sample["label"] = _char_to_label(file_path.stem[0])
+        return sample
 
     def _collate(self, batch):
-        graphs, labels = map(list, zip(*batch))
-        labels = torch.cat(labels, dim=0)
-        bg = dgl.batch(graphs)
-        return bg, labels
-
-    def get_dataloader(self, batch_size=64, shuffle=True):
-        return DataLoader(
-            self,
-            batch_size=batch_size,
-            shuffle=shuffle,
-            collate_fn=self._collate,
-            num_workers=0,  # Can be set to non-zero on Linux
-            drop_last=True,
-        )
+        collated = super()._collate(batch)
+        collated["label"] =  torch.cat([x["label"] for x in batch], dim=0)
+        return collated

--- a/datasets/solidletters.py
+++ b/datasets/solidletters.py
@@ -78,7 +78,7 @@ class SolidLetters(Dataset):
             self.graphs.append(load_graphs(str(fn))[0][0])
         if self.center_and_scale:
             for i in range(len(self.graphs)):
-                self.graphs[i].ndata["x"] = util.center_and_scale_uvsolid(
+                self.graphs[i].ndata["x"] = util.center_and_scale_uvgrid(
                     self.graphs[i].ndata["x"]
                 )
 

--- a/datasets/util.py
+++ b/datasets/util.py
@@ -6,8 +6,8 @@ from scipy.spatial.transform import Rotation
 
 
 def bounding_box_uvgrid(inp: torch.Tensor):
-    pts = inp[:, :, :, :3].reshape((-1, 3))
-    mask = inp[:, :, :, 6].reshape(-1)
+    pts = inp[..., :3].reshape((-1, 3))
+    mask = inp[..., 6].reshape(-1)
     point_indices_inside_faces = mask == 1
     pts = pts[point_indices_inside_faces, :]
     return bounding_box_pointcloud(pts)
@@ -26,8 +26,8 @@ def center_and_scale_uvgrid(inp: torch.Tensor, return_center_scale=False):
     diag = bbox[1] - bbox[0]
     scale = 2.0 / max(diag[0], diag[1], diag[2])
     center = 0.5 * (bbox[0] + bbox[1])
-    inp[:, :, :, :3] -= center
-    inp[:, :, :, :3] *= scale
+    inp[..., :3] -= center
+    inp[..., :3] *= scale
     if return_center_scale:
         return inp, center, scale
     return inp
@@ -49,11 +49,11 @@ def get_random_rotation():
 def rotate_uvgrid(inp, rotation):
     """Rotate the node features in the graph by a given rotation"""
     Rmat = torch.tensor(rotation.as_matrix()).float()
-    orig_size = inp[:, :, :, :3].size()
-    inp[:, :, :, :3] = torch.mm(inp[:, :, :, :3].view(-1, 3), Rmat).view(
+    orig_size = inp[..., :3].size()
+    inp[..., :3] = torch.mm(inp[..., :3].view(-1, 3), Rmat).view(
         orig_size
     )  # Points
-    inp[:, :, :, 3:6] = torch.mm(inp[:, :, :, 3:6].view(-1, 3), Rmat).view(
+    inp[..., 3:6] = torch.mm(inp[..., 3:6].view(-1, 3), Rmat).view(
         orig_size
     )  # Normals/tangents
     return inp

--- a/datasets/util.py
+++ b/datasets/util.py
@@ -1,7 +1,11 @@
+import random
+
+import numpy as np
 import torch
+from scipy.spatial.transform import Rotation
 
 
-def bounding_box_uvsolid(inp: torch.Tensor):
+def bounding_box_uvgrid(inp: torch.Tensor):
     pts = inp[:, :, :, :3].reshape((-1, 3))
     mask = inp[:, :, :, 6].reshape(-1)
     point_indices_inside_faces = mask == 1
@@ -17,8 +21,8 @@ def bounding_box_pointcloud(pts: torch.Tensor):
     return torch.tensor(box)
 
 
-def center_and_scale_uvsolid(inp: torch.Tensor, return_center_scale=False):
-    bbox = bounding_box_uvsolid(inp)
+def center_and_scale_uvgrid(inp: torch.Tensor, return_center_scale=False):
+    bbox = bounding_box_uvgrid(inp)
     diag = bbox[1] - bbox[0]
     scale = 2.0 / max(diag[0], diag[1], diag[2])
     center = 0.5 * (bbox[0] + bbox[1])
@@ -28,6 +32,31 @@ def center_and_scale_uvsolid(inp: torch.Tensor, return_center_scale=False):
         return inp, center, scale
     return inp
 
+
+def get_random_rotation():
+    """Get a random rotation in 90 degree increments along the canonical axes"""
+    axes = [
+        np.array([1, 0, 0]),
+        np.array([0, 1, 0]),
+        np.array([0, 0, 1]),
+    ]
+    angles = [0.0, 90.0, 180.0, 270.0]
+    axis = random.choice(axes)
+    angle_radians = np.radians(random.choice(angles))
+    return Rotation.from_rotvec(angle_radians * axis)
+
+
+def rotate_uvgrid(inp, rotation):
+    """Rotate the node features in the graph by a given rotation"""
+    Rmat = torch.tensor(rotation.as_matrix()).float()
+    orig_size = inp[:, :, :, :3].size()
+    inp[:, :, :, :3] = torch.mm(inp[:, :, :, :3].view(-1, 3), Rmat).view(
+        orig_size
+    )  # Points
+    inp[:, :, :, 3:6] = torch.mm(inp[:, :, :, 3:6].view(-1, 3), Rmat).view(
+        orig_size
+    )  # Normals/tangents
+    return inp
 
 
 INVALID_FONTS = [

--- a/segmentation.py
+++ b/segmentation.py
@@ -80,6 +80,7 @@ if args.traintest == "train":
     trainer.fit(model, train_loader, val_loader)
 else:
     # Test
+    assert args.checkpoint is not None, "Expected the --checkpoint argument to be provided"
     model = Segmentation.load_from_checkpoint(args.checkpoint)
     test_data = Dataset(
         root_dir=args.dataset_path, split="test", random_rotate=args.random_rotate

--- a/segmentation.py
+++ b/segmentation.py
@@ -1,5 +1,6 @@
 import argparse
 
+import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger
@@ -9,12 +10,29 @@ from datasets.fusiongallery import FusionGalleryDataset
 from uvnet.models import Segmentation
 
 parser = argparse.ArgumentParser("UV-Net solid model face segmentation")
-parser.add_argument("traintest", choices=("train", "test"), help="Whether to train or test")
-parser.add_argument("--dataset", choices=("mfcad", "fusiongallery"), help="Segmentation dataset")
+parser.add_argument(
+    "traintest", choices=("train", "test"), help="Whether to train or test"
+)
+parser.add_argument(
+    "--dataset", choices=("mfcad", "fusiongallery"), help="Segmentation dataset"
+)
 parser.add_argument("--dataset_path", type=str, help="Path to dataset")
 parser.add_argument("--epochs", type=int, default=100, help="Number of epochs to train")
 parser.add_argument("--batch_size", type=int, default=64, help="Batch size")
-parser.add_argument("--checkpoint", type=str, default=None, help="Checkpoint file to load weights from for testing")
+parser.add_argument(
+    "--cpu", action="store_true", help="Use the CPU for training/testing"
+)
+parser.add_argument(
+    "--random_rotate",
+    action="store_true",
+    help="Whether to randomly rotate the solids in 90 degree increments along the canonical axes",
+)
+parser.add_argument(
+    "--checkpoint",
+    type=str,
+    default=None,
+    help="Checkpoint file to load weights from for testing",
+)
 
 args = parser.parse_args()
 
@@ -24,24 +42,25 @@ checkpoint_callback = ModelCheckpoint(
     filename="best-{epoch}-{val_loss:.2f}",
     save_last=True,
 )
+
+use_cpu = args.cpu or (not torch.cuda.is_available())
 trainer = Trainer(
-    gpus=1,
+    gpus=None if use_cpu else 1,
     callbacks=[checkpoint_callback],
     check_val_every_n_epoch=1,
     max_epochs=args.epochs,
-    logger=TensorBoardLogger("segmentation_logs")
+    logger=TensorBoardLogger("segmentation_logs"),
 )
 
 if args.dataset == "mfcad":
     Dataset = MFCADDataset
 elif args.dataset == "fusiongallery":
-    pass
     Dataset = FusionGalleryDataset
 
 if args.traintest == "train":
     # Train/val
     model = Segmentation(num_classes=Dataset.num_classes())
-    train_data = Dataset(root_dir=args.dataset_path, split="train")
+    train_data = Dataset(root_dir=args.dataset_path, split="train", random_rotate=args.random_rotate)
     val_data = Dataset(root_dir=args.dataset_path, split="val")
     train_loader = train_data.get_dataloader(batch_size=args.batch_size, shuffle=True)
     val_loader = val_data.get_dataloader(batch_size=args.batch_size, shuffle=False)
@@ -49,9 +68,7 @@ if args.traintest == "train":
 else:
     # Test
     model = Segmentation.load_from_checkpoint(args.checkpoint)
-    test_data = Dataset(root_dir=args.dataset_path, split="test")
+    test_data = Dataset(root_dir=args.dataset_path, split="test", random_rotate=args.random_rotate)
     test_loader = test_data.get_dataloader(batch_size=args.batch_size, shuffle=False)
-    results = trainer.test(model=model, test_dataloaders=[test_loader])
-    print(
-        f"Segmentation IoU (%) on test set: {results[0]['test_iou'] * 100.0}"
-    )
+    results = trainer.test(model=model, test_dataloaders=[test_loader], verbose=False)
+    print(f"Segmentation IoU (%) on test set: {results[0]['test_iou'] * 100.0}")

--- a/uvnet/models.py
+++ b/uvnet/models.py
@@ -142,7 +142,8 @@ class Classification(pl.LightningModule):
         return logits
 
     def training_step(self, batch, batch_idx):
-        inputs, labels = batch
+        inputs = batch["graph"].to(self.device)
+        labels = batch["labels"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
@@ -156,7 +157,8 @@ class Classification(pl.LightningModule):
         self.log("train_acc_epoch", self.train_acc.compute())
 
     def validation_step(self, batch, batch_idx):
-        inputs, labels = batch
+        inputs = batch["graph"].to(self.device)
+        labels = batch["labels"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
@@ -170,7 +172,8 @@ class Classification(pl.LightningModule):
         self.log("val_acc_epoch", self.val_acc.compute())
 
     def test_step(self, batch, batch_idx):
-        inputs, labels = batch
+        inputs = batch["graph"].to(self.device)
+        labels = batch["labels"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
@@ -291,7 +294,7 @@ class Segmentation(pl.LightningModule):
         return logits
 
     def training_step(self, batch, batch_idx):
-        inputs = batch
+        inputs = batch["graph"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         labels = inputs.ndata["y"]
@@ -306,7 +309,7 @@ class Segmentation(pl.LightningModule):
         self.log("train_iou", self.train_iou.compute())
 
     def validation_step(self, batch, batch_idx):
-        inputs = batch
+        inputs = batch["graph"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         labels = inputs.ndata["y"]
@@ -321,7 +324,7 @@ class Segmentation(pl.LightningModule):
         self.log("val_iou", self.val_iou.compute())
 
     def test_step(self, batch, batch_idx):
-        inputs = batch
+        inputs = batch["graph"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         labels = inputs.ndata["y"]

--- a/uvnet/models.py
+++ b/uvnet/models.py
@@ -143,7 +143,7 @@ class Classification(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         inputs = batch["graph"].to(self.device)
-        labels = batch["labels"].to(self.device)
+        labels = batch["label"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
@@ -158,7 +158,7 @@ class Classification(pl.LightningModule):
 
     def validation_step(self, batch, batch_idx):
         inputs = batch["graph"].to(self.device)
-        labels = batch["labels"].to(self.device)
+        labels = batch["label"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
@@ -173,7 +173,7 @@ class Classification(pl.LightningModule):
 
     def test_step(self, batch, batch_idx):
         inputs = batch["graph"].to(self.device)
-        labels = batch["labels"].to(self.device)
+        labels = batch["label"].to(self.device)
         inputs.ndata["x"] = inputs.ndata["x"].permute(0, 3, 1, 2)
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)

--- a/uvnet/models.py
+++ b/uvnet/models.py
@@ -148,13 +148,10 @@ class Classification(pl.LightningModule):
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("train_loss", loss)
+        self.log("train_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
-        self.log("train_acc_step", self.train_acc(preds, labels))
+        self.log("train_acc", self.train_acc(preds, labels), on_step=False, on_epoch=True)
         return loss
-
-    def training_epoch_end(self, outs):
-        self.log("train_acc_epoch", self.train_acc.compute())
 
     def validation_step(self, batch, batch_idx):
         inputs = batch["graph"].to(self.device)
@@ -163,13 +160,10 @@ class Classification(pl.LightningModule):
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("val_loss", loss)
+        self.log("val_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
-        self.log("val_acc_step", self.val_acc(preds, labels))
+        self.log("val_acc", self.val_acc(preds, labels), on_step=False, on_epoch=True)
         return loss
-
-    def validation_epoch_end(self, outs):
-        self.log("val_acc_epoch", self.val_acc.compute())
 
     def test_step(self, batch, batch_idx):
         inputs = batch["graph"].to(self.device)
@@ -178,12 +172,9 @@ class Classification(pl.LightningModule):
         inputs.edata["x"] = inputs.edata["x"].permute(0, 2, 1)
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("test_loss", loss)
+        self.log("test_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
-        self.log("test_acc_step", self.test_acc(preds, labels))
-
-    def test_epoch_end(self, outs):
-        self.log("test_acc_epoch", self.test_acc.compute())
+        self.log("test_acc", self.test_acc(preds, labels), on_step=False, on_epoch=True)
 
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters())
@@ -300,7 +291,7 @@ class Segmentation(pl.LightningModule):
         labels = inputs.ndata["y"]
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("train_loss", loss)
+        self.log("train_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
         self.train_iou(preds, labels)
         return loss
@@ -315,7 +306,7 @@ class Segmentation(pl.LightningModule):
         labels = inputs.ndata["y"]
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("val_loss", loss)
+        self.log("val_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
         self.val_iou(preds, labels)
         return loss
@@ -330,7 +321,7 @@ class Segmentation(pl.LightningModule):
         labels = inputs.ndata["y"]
         logits = self.model(inputs)
         loss = F.cross_entropy(logits, labels, reduction="mean")
-        self.log("test_loss", loss)
+        self.log("test_loss", loss, on_step=False, on_epoch=True)
         preds = F.softmax(logits, dim=-1)
         self.test_iou(preds, labels)
 


### PR DESCRIPTION
Changed how datasets are implemented. 

- Created a `BaseDataset` that abstracts the graph loading functionality. All datasets derive from this class and primarily take care of handling data split, paths etc.
- Dataset samples are now dictionaries and allow storing additional metadata such as filenames. The graph itself is stored in a key called `"graph"`. Additional metadata can be added in the derived dataset classes.

Other miscellaneous tweaks:

- Exposed PyTorch Lightning `Trainer`'s arguments in the CLI.
- Using a random 20% validation split in the FusionGallery dataset. Previously there was no held out validation set.
- Bugfix to center and scale edge UV-grids.
- Minor fix to save one best checkpoint rather than a whole bunch of them.