### PR TITLE
Add some fixes to update UV-Net to run on the s2 release of the Fusion Gallery segmentation dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ dmypy.json
 .pyre/
 
 results/*
+.vscode/
+run_scripts/
+segmentation_checkpoints/
+segmentation_logs/
+segmentation_pretrained/

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -28,6 +28,13 @@ class FusionGalleryDataset(BaseDataset):
         """
         path = pathlib.Path(root_dir)
         self.path = path
+
+        # Locate the labels directory.  In s1.0.0 this would be  self.path / "breps"
+        # but in s2.0.0 this is self.path / "breps/seg"
+        self.seg_path = self.path / "breps/seg"
+        if not seg_path.exists():
+            self.seg_path = self.path / "breps"
+
         assert split in ("train", "val", "test")
 
         with open(str(path.joinpath("train_test.json")), "r") as read_file:
@@ -61,7 +68,7 @@ class FusionGalleryDataset(BaseDataset):
         sample = super().load_one_graph(file_path)
         # Additionally load the label and store it as node data
         label = np.loadtxt(
-            self.path.joinpath("breps/seg").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
+            self.seg_path.joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
         )
         if sample["graph"].number_of_nodes() != label.shape[0]:
             return None

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -61,7 +61,7 @@ class FusionGalleryDataset(BaseDataset):
         sample = super().load_one_graph(file_path)
         # Additionally load the label and store it as node data
         label = np.loadtxt(
-            self.path.joinpath("breps").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
+            self.path.joinpath("breps/seg").joinpath(file_path.stem + ".seg"), dtype=np.int, ndmin=1
         )
         if sample["graph"].number_of_nodes() != label.shape[0]:
             return None

--- a/datasets/fusiongallery.py
+++ b/datasets/fusiongallery.py
@@ -32,7 +32,7 @@ class FusionGalleryDataset(BaseDataset):
         # Locate the labels directory.  In s1.0.0 this would be  self.path / "breps"
         # but in s2.0.0 this is self.path / "breps/seg"
         self.seg_path = self.path / "breps/seg"
-        if not seg_path.exists():
+        if not self.seg_path.exists():
             self.seg_path = self.path / "breps"
 
         assert split in ("train", "val", "test")

--- a/segmentation.py
+++ b/segmentation.py
@@ -31,6 +31,12 @@ parser.add_argument(
     help="Whether to randomly rotate the solids in 90 degree increments along the canonical axes",
 )
 parser.add_argument(
+    "--crv_in_channels",
+    type=int,
+    default=6,
+    help="Number of channels for curve input",
+)
+parser.add_argument(
     "--checkpoint",
     type=str,
     default=None,
@@ -92,7 +98,10 @@ results/{args.experiment_name}/{month_day}/{hour_min_second}/best.ckpt
 -----------------------------------------------------------------------------------
     """
     )
-    model = Segmentation(num_classes=Dataset.num_classes())
+    model = Segmentation(
+        num_classes=Dataset.num_classes(), 
+        crv_in_channels=args.crv_in_channels
+    )
     train_data = Dataset(
         root_dir=args.dataset_path, split="train", random_rotate=args.random_rotate
     )

--- a/uvnet/models.py
+++ b/uvnet/models.py
@@ -194,6 +194,7 @@ class UVNetSegmenter(nn.Module):
     def __init__(
         self,
         num_classes,
+        crv_in_channels=6,
         crv_emb_dim=64,
         srf_emb_dim=64,
         graph_emb_dim=128,
@@ -204,6 +205,7 @@ class UVNetSegmenter(nn.Module):
 
         Args:
             num_classes (int): Number of classes to output per-face
+            crv_in_channels (int, optional): Number of input channels for the 1D edge UV-grids
             crv_emb_dim (int, optional): Embedding dimension for the 1D edge UV-grids. Defaults to 64.
             srf_emb_dim (int, optional): Embedding dimension for the 2D face UV-grids. Defaults to 64.
             graph_emb_dim (int, optional): Embedding dimension for the graph. Defaults to 128.
@@ -212,7 +214,7 @@ class UVNetSegmenter(nn.Module):
         super().__init__()
         # A 1D convolutional network to encode B-rep edge geometry represented as 1D UV-grids
         self.curv_encoder = uvnet.encoders.UVNetCurveEncoder(
-            in_channels=6, output_dims=crv_emb_dim
+            in_channels=crv_in_channels, output_dims=crv_emb_dim
         )
         # A 2D convolutional network to encode B-rep face geometry represented as 2D UV-grids
         self.surf_encoder = uvnet.encoders.UVNetSurfaceEncoder(
@@ -263,14 +265,14 @@ class Segmentation(pl.LightningModule):
     PyTorch Lightning module to train/test the segmenter (per-face classifier).
     """
 
-    def __init__(self, num_classes):
+    def __init__(self, num_classes, crv_in_channels=6):
         """
         Args:
             num_classes (int): Number of per-face classes in the dataset
         """
         super().__init__()
         self.save_hyperparameters()
-        self.model = UVNetSegmenter(num_classes)
+        self.model = UVNetSegmenter(num_classes, crv_in_channels=crv_in_channels)
         # Setting compute_on_step = False to compute "part IoU"
         # This is because we want to compute the IoU on the entire dataset
         # at the end to account for rare classes, rather than within each batch


### PR DESCRIPTION
# Fusion Gallery Segmentation Dataset Compatibility

The second release of the [Fusion Gallery Segmentation Dataset](https://github.com/AutodeskAILab/Fusion360GalleryDataset) uses STEP data in place of Autodesk SMT files.  The [extended STEP dataset](https://github.com/AutodeskAILab/Fusion360GalleryDataset/blob/master/docs/segmentation.md#segmentation-extended-step-dataset) provides an additional 7054 models which were too complicated to mesh for MeshCNN.

The s2.0.0 release places the STEP and segmentation information in the following folder structure

```
s2.0.0
  |
  +-- breps
          |
         +-- step    (STEP data in here) 
          |
         +-- seg    (segmentation labels in here)
```  

Also to get this working we need to

- Convert float64 to float32 values
- Filter out models with no edges

It is also valuable to allow the number of input curve features to be adjusted. 

# Monitor accuracy as well as IoU
There is no way to monitor segmentation accuracy.   This is now added to the segmentation model. 